### PR TITLE
Export variables to run on NVIDIA

### DIFF
--- a/etc/profile.d/wayfire.sh
+++ b/etc/profile.d/wayfire.sh
@@ -1,3 +1,6 @@
-if lspci -k | grep "Kernel driver in use" | grep nouveau; then 
-	export WLR_NO_HARDWARE_CURSORS=1
+if [ -d /sys/module/nvidia ]; then
+    export WLR_NO_HARDWARE_CURSORS=1
+    export GBM_BACKEND=nvidia-drm
+    export EGL_PLATFORM=wayland
+    export __GLX_VENDOR_LIBRARY_NAME=nvidia
 fi


### PR DESCRIPTION
We have already enabled `nvidia-drm.modeset=1` by default (https://github.com/CachyOS/CachyOS-Settings/pull/7) , but we also need to export `GBM_BACKEND=nvidia-gbm` for wlroots-based composers to work properly.